### PR TITLE
Allow coverage reporting to be visible to PRs

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -41,4 +41,42 @@ jobs:
     - name: Set up Hatch
       uses: pypa/hatch@a3c83ab3d481fbc2dc91dd0088628817488dd1d5
     - name: Run unit tests (with coverage report at the end)
-      run: hatch test -c -py ${{ matrix.python-version }}
+      run:  |
+        if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.python-version }}" == "3.11" ]]; then
+          hatch test -c -py ${{ matrix.python-version }} | tee > cov.txt
+        else
+          hatch test -c -py ${{ matrix.python-version }}
+        fi
+
+    - name: Comment Missed Lines
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      run: |
+        awk '/Name/{flag=1; next} /TOTAL/{flag=0; next} flag && !/^[-]+$/' cov.txt | while IFS= read -r line; do
+
+            # Extract file name and missing ranges
+            file_name=$(echo "$line" | awk '{print $1}')
+            missing_lines=$(echo "$line" | awk '{for (i=5; i<=NF; i++) printf $i " "; print ""}')
+
+            # Process each range
+            for range in $missing_lines; do
+                # Trim leading and trailing whitespace
+                range=$(echo "$range" | xargs)
+                line_start=""
+                line_end=""
+                message=""
+
+                if [[ "$range" == *"-"* ]]; then
+                    # Split range into start and end
+                    line_start=$(echo "$range" | cut -d'-' -f1)
+                    line_end=$(echo "$range" | cut -d'-' -f2)
+                    message="The following lines were not covered in your tests: $line_start to $line_end"
+                else
+                    # Single line number
+                    line_start=$range
+                    line_end=$range
+                    message="The following line was not covered in your tests: $line_start"
+                fi
+
+                echo "::warning file=$file_name,line=$line_start,endLine=$line_end::$message"
+            done
+        done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ keywords = [
 [project.urls]
 Homepage = "https://pypi.org/project/model-signing/"
 Changelog = "https://github.com/sigstore/model-transparency/blob/main/CHANGELOG.md"
-Documentation = "https://sigstore.github.io/model-transparency/model_signing.html"
+# TODO: https://github.com/sigstore/model-transparency/pull/279 - Documentation = "...."
 Source = "https://github.com/sigstore/model-transparency"
 Issues = "https://github.com/sigstore/model-transparency/issues"
 PyPI = "https://pypi.org/project/model-signing/"
@@ -63,6 +63,18 @@ randomize = true
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.11", "3.12"]
 
+[tool.hatch.envs.docs]
+description = """Custom environment for pdoc.
+Use `hatch run docs:serve` to view documentation.
+"""
+extra-dependencies = [
+  "pdoc"
+]
+
+[tool.hatch.envs.docs.scripts]
+serve = "pdoc src/model_signing --docformat google --no-show-source"
+build = "serve --output-directory html"
+
 [tool.hatch.envs.type]
 description = """Custom environment for pytype.
 Use `hatch run type:check` to check types.
@@ -77,17 +89,15 @@ python = "3.11"
 [tool.hatch.envs.type.scripts]
 check = "pytype -k -j auto src tests"
 
-[tool.hatch.envs.docs]
-description = """Custom environment for pdoc.
-Use `hatch run docs:serve` to view documentation.
-"""
-extra-dependencies = [
-  "pdoc"
+[tool.coverage.report]
+exclude_also = [
+  "pass",
+  "return NotImplemented",
 ]
-
-[tool.hatch.envs.docs.scripts]
-serve = "pdoc src/model_signing --docformat google --no-show-source"
-build = "serve --output-directory html"
+omit = ["tests/*"]
+show_missing = true
+skip_covered = true
+skip_empty = true
 
 # Add support for testing via the old `pytest .` way, too.
 [tool.pytest.ini_options]


### PR DESCRIPTION
The problem is that the coverage report is being displayed on the command line, and it would be ideal to have a GitHub formatted output that shows up in code files in the PR that highlights the lines of code that were not covered in the unit test CI workflow. Doing so, it would assist reviewers in ensuring that the code coverage is high.

The unit_tests workflow has been modified to:
- Create a coverage file only if the specified OS and python version finish the test
- Run a step to process the file and extract the file names and the missed lines/ranges and highlight the lines using workflow commands

Resolves: #288