### PR TITLE
Enhancing coverage reporting

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -41,4 +41,39 @@ jobs:
     - name: Set up Hatch
       uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
     - name: Run unit tests (with coverage report at the end)
-      run: hatch test -c -py ${{ matrix.python-version }}
+      run: |
+        if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.python-version }}" == "3.11" ]]; then
+          hatch test -c -py ${{ matrix.python-version }} | tee > cov.txt
+        else
+          hatch test -c -py ${{ matrix.python-version }}
+        fi
+
+    - name: Highlight missing lines
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      run: |
+        awk '/Name/{flag=1; next} /TOTAL/{flag=0; next} flag && !/^[-]+$/' cov.txt | while IFS= read -r line; do
+          # Extract file name and missing ranges
+          file_name=$(echo "$line" | awk '{print $1}')
+          missing_lines=$(echo "$line" | awk '{for (i=5; i<=NF; i++) printf $i " "; print ""}')
+          # Process each range
+          for range in $missing_lines; do
+            # Trim leading and trailing whitespace
+            range=$(echo "$range" | xargs)
+            line_start=""
+            line_end=""
+            message=""
+            if [[ "$range" == *"-"* ]]; then
+              # Split range into start and end
+              line_start=$(echo "$range" | cut -d'-' -f1)
+              line_end=$(echo "$range" | cut -d'-' -f2)
+              message="The following lines were not covered in your tests: $line_start to $line_end"
+            else
+              # Single line number
+              line_start=$range
+              line_end=$range
+              message="The following line was not covered in your tests: $line_start"
+            fi
+
+            echo "::warning file=$file_name,line=$line_start,endLine=$line_end::$message"
+          done
+        done


### PR DESCRIPTION
The problem is that the coverage report is being displayed on the command line, and it would be ideal to have a GitHub formatted output that shows up in code files

in the PR that highlights the lines of code that were not covered in the unit test CI workflow. Doing do, would assist reviewers in ensuring that the code coverage is high.

The unit_tests workflow has been modified to:
- Create a coverage file only if the specified OS and python version finish the test
- Run a step to process the file and extract the file names and the missed lines/ranges and highlight the lines using workflow commands

Resolves: #288